### PR TITLE
add anti-hard-coding tests

### DIFF
--- a/spec/conference_badges_spec.rb
+++ b/spec/conference_badges_spec.rb
@@ -68,6 +68,9 @@ TEXT
     it 'should return a list of badge messages' do
       expect(batch_badge_creator(attendees)).to eq(badges)
     end
+    it 'should not hard-code response' do
+      expect(batch_badge_creator(["Johnny"])).to eq(["Hello, my name is Johnny."])
+    end
 
   end
 
@@ -77,6 +80,9 @@ TEXT
 
     it 'should return a list of welcome messages and room assignments' do
       expect(assign_rooms(attendees)).to eq(room_assignments)
+    end
+    it 'should not hard-code the response' do
+      expect(assign_rooms(["Steve"])).to eq(["Hello, Steve! You'll be assigned to room 1!"])
     end
 
   end


### PR DESCRIPTION
Saw student had hard-coded the responses and the tests lacked two-point checks.
Added in simple test to inject a single-value array so the responses cannot be hard-coded.

CC: @AnnJohn 
