### PR TITLE
cleaner solution for #assign_rooms

### DIFF
--- a/conference_badges.rb
+++ b/conference_badges.rb
@@ -13,8 +13,8 @@ def batch_badge_creator(attendees)
 end
 
 def assign_rooms(attendees)
-  attendees.each_with_index.map do |attendee, index|
-    "Hello, #{attendee}! You'll be assigned to room #{index+1}!"
+  attendees.map.with_index(1) do |attendee, index|
+    "Hello, #{attendee}! You'll be assigned to room #{index}!"
   end
 end
 


### PR DESCRIPTION
@jmburges Besides being cleaner IMHO, I think it's a good idea to show students they can use [`#with_index`](http://ruby-doc.org/core-2.2.3/Enumerator.html#method-i-with_index) on the enumerator that `#map` returns when it isn't called with a block. Thoughts? If you agree, :shipit: :).  cc @ruthmesfun 